### PR TITLE
Fix issue with devenv deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ target/
 
 # dfx temporary files
 .dfx/
+canister_ids.json
 
 # frontend code
 node_modules/

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@ Before building the wasm you need to specify the environment variables of the co
 
 The needed env vars are:
 
-* `PUBLIC_INTERNET_IDENTITY_URL`.
-* `PUBLIC_HOST`.
-* `PUBLIC_OWN_CANISTER_ID`. Used only for local development.
+* `PUBLIC_INTERNET_IDENTITY_URL`. Ex: `http://bnz7o-iuaaa-aaaaa-qaaaa-cai.localhost:8080`.
+* `PUBLIC_HOST`. Ex: `http://localhost:8080`.
+* `PUBLIC_OWN_CANISTER_ID`. Used only for local development. Ex: `bw4dl-smaaa-aaaaa-qaacq-cai`
+* `PUBLIC_FETCH_ROOT_KEY`. Whether client should fetch root key before making calls. Used for development environments. Ex: `true`.
 
 To set the vars you need to put then in the `.env` file.
 

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -3,6 +3,7 @@ interface ImportMetaEnv {
   readonly PUBLIC_INTERNET_IDENTITY_URL: string;
   readonly PUBLIC_HOST: string;
   readonly PUBLIC_OWN_CANISTER_ID: string;
+  readonly PUBLIC_FETCH_ROOT_KEY: string;
 }
 
 interface ImportMeta {

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -89,11 +89,11 @@ import Success from "../pages/success.astro";
   const host = import.meta.env.PUBLIC_HOST;
   const mainAppElement = document.querySelector("[data-app]") as HTMLElement;
   const canisterId = mainAppElement.dataset.canisterId ?? import.meta.env.PUBLIC_OWN_CANISTER_ID;
+  const fetchRootKey = import.meta.env.PUBLIC_FETCH_ROOT_KEY === "true";
 
   const busyScreen = document.getElementById('busy') as HTMLDivElement;
 
   const login = () => {
-
     return new Promise((resolve) => {
       busyScreen.classList.remove('hide');
 
@@ -101,7 +101,7 @@ import Success from "../pages/success.astro";
         onSuccess: async () => {
           const identity = authClient.getIdentity();
           const agent = new HttpAgent({ identity, host });
-          if (import.meta.env.DEV) {
+          if (fetchRootKey) {
             await agent.fetchRootKey();
           }
           const webapp: _SERVICE = Actor.createActor(webapp_idl, {


### PR DESCRIPTION
There was an issue with the call to backend with the deployed version in local or a dev environment. The problem was that the root key was not being fetched because it was using the production build.

In this PR, I add one more env var `PUBLIC_FETCH_ROOT_KEY` to set this instead of relying in the build mode.