### PR TITLE
Use dfx generate to create the Actor

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -5,6 +5,7 @@
       "type": "custom",
       "candid": "early_adopter_issuer.did",
       "wasm": "early_adopter_issuer.wasm.gz",
+      "output": "frontend/declarations",
       "build": "./build.sh",
       "shrink": false
     },

--- a/frontend/scripts/generate-actor.sh
+++ b/frontend/scripts/generate-actor.sh
@@ -1,0 +1,13 @@
+print_help() {
+  cat <<-EOF
+	Generates the actor needed to talk to the canister.
+	EOF
+}
+
+# Generate the actor
+dfx generate early_adopter
+# We are not using the default `createActor` function because we want to control the fetchRootKey with an env var.
+# We need to remove the code because it uses process.env which is not available in the browser.
+# We use a custom `createActor` from "src/utils/actor" to create the actor.
+# We still need to export the idlFactory from the generated file.
+echo 'export { idlFactory } from "./early_adopter.did.js";' > "./src/declarations/early_adopter/index.js"

--- a/frontend/src/declarations/early_adopter/early_adopter.did
+++ b/frontend/src/declarations/early_adopter/early_adopter.did
@@ -1,0 +1,117 @@
+/// Candid interface of the example VC issuer canister.
+/// The interface contains both the functionality required by the VC-spec
+/// (https://github.com/dfinity/internet-identity/blob/main/docs/vc-spec.md)
+/// and additional APIs for configuring the canister and using it for testing.
+
+/// Types for specification of a requested credential, and managing data related to the credentials.
+type CredentialSpec = record {
+    credential_type : text;
+    /// arguments are optional, and specific to the credential_name
+    arguments : opt vec record { text; ArgumentValue };
+};
+type ArgumentValue = variant { "Int" : int32; String : text };
+type EarlyAdopterStatus = record { joined_timestamp_s : nat32 };
+type EarlyAdopterError = variant { Internal : text };
+
+/// Types for ICRC-21 consent message, cf.
+/// https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_21_consent_msg.md
+type Icrc21ConsentInfo = record { consent_message : text; language : text };
+type Icrc21ConsentPreferences = record { language : text };
+type Icrc21Error = variant {
+    GenericError : record { description : text; error_code : nat };
+    UnsupportedCanisterCall : Icrc21ErrorInfo;
+    ConsentMessageUnavailable : Icrc21ErrorInfo;
+};
+type Icrc21ErrorInfo = record { description : text };
+type Icrc21VcConsentMessageRequest = record {
+    preferences : Icrc21ConsentPreferences;
+    credential_spec : CredentialSpec;
+};
+
+/// Types for requesting issuance of a credential.
+/// The issuance proceeds in two steps:
+///  - `prepare_credential`, and
+///  - `get_credential`
+/// where the split of work between the two steps depends on the specifics of the issuer,
+/// and the second second step returns the actual credential (if any).
+/// The two steps can use `prepared_context`-value to transfer information between them.
+
+/// Types for `prepare_credential`.
+type PrepareCredentialRequest = record {
+    signed_id_alias : SignedIdAlias;
+    credential_spec : CredentialSpec;
+};
+type PreparedCredentialData = record { prepared_context : opt vec nat8 };
+
+/// Types for `get_credential`.
+type GetCredentialRequest = record {
+    signed_id_alias : SignedIdAlias;
+    credential_spec : CredentialSpec;
+    prepared_context : opt vec nat8;
+};
+
+type SignedIdAlias = record {
+    credential_jws : text;
+};
+type IssuedCredentialData = record { vc_jws : text };
+type IssueCredentialError = variant {
+    /// The caller is not known to the issuer.  Caller should register first with the issuer before retrying.
+    UnknownSubject : text;
+    /// The caller is not authorized to obtain the requested credential.  Caller requested a credential
+    /// for a different principal, or the issuer does not have sufficient knowledge about the caller
+    /// to issue the requested credential.
+    UnauthorizedSubject : text;
+    /// The id_alias credential provided by the identity provider is invalid.
+    InvalidIdAlias : text;
+    /// The issuer does not issue credentials described in the credential spec.
+    UnsupportedCredentialSpec : text;
+    /// Internal errors, indicate malfunctioning of the issuer.
+    SignatureNotFound : text;
+    Internal : text;
+};
+
+/// Configuration specific to this issuer.
+type IssuerConfig = record {
+    /// Root of trust for checking canister signatures.
+    ic_root_key_der : blob;
+    /// List of canister ids that are allowed to provide id alias credentials.
+    idp_canister_ids : vec principal;
+};
+
+/// Options related to HTTP handling
+
+type HeaderField = record {
+    text;
+    text;
+};
+
+type HttpRequest = record {
+    method: text;
+    url: text;
+    headers: vec HeaderField;
+    body: blob;
+    certificate_version: opt nat16;
+};
+
+type HttpResponse = record {
+    status_code: nat16;
+    headers: vec HeaderField;
+    body: blob;
+};
+
+service: (opt IssuerConfig) -> {
+    /// VC-flow API.
+    vc_consent_message : (Icrc21VcConsentMessageRequest) -> (variant { Ok : Icrc21ConsentInfo; Err : Icrc21Error });
+    prepare_credential : (PrepareCredentialRequest) -> (variant { Ok : PreparedCredentialData; Err : IssueCredentialError });
+    get_credential : (GetCredentialRequest) -> (variant { Ok : IssuedCredentialData; Err : IssueCredentialError }) query;
+
+    /// Configure the issuer (e.g. set the root key), used for deployment/testing.
+    configure: (IssuerConfig) -> ();
+
+    /// Register a user as an early adopter.
+    register_early_adopter : () ->  (variant { Ok : EarlyAdopterStatus; Err : EarlyAdopterError });
+
+    /// Serve the app
+    http_request: (request: HttpRequest) -> (HttpResponse) query;
+}
+

--- a/frontend/src/declarations/early_adopter/early_adopter.did.d.ts
+++ b/frontend/src/declarations/early_adopter/early_adopter.did.d.ts
@@ -1,0 +1,87 @@
+import type { Principal } from '@dfinity/principal';
+import type { ActorMethod } from '@dfinity/agent';
+
+export type ArgumentValue = { 'Int' : number } |
+  { 'String' : string };
+export interface CredentialSpec {
+  'arguments' : [] | [Array<[string, ArgumentValue]>],
+  'credential_type' : string,
+}
+export type EarlyAdopterError = { 'Internal' : string };
+export interface EarlyAdopterStatus { 'joined_timestamp_s' : number }
+export interface GetCredentialRequest {
+  'signed_id_alias' : SignedIdAlias,
+  'prepared_context' : [] | [Uint8Array | number[]],
+  'credential_spec' : CredentialSpec,
+}
+export type HeaderField = [string, string];
+export interface HttpRequest {
+  'url' : string,
+  'method' : string,
+  'body' : Uint8Array | number[],
+  'headers' : Array<HeaderField>,
+  'certificate_version' : [] | [number],
+}
+export interface HttpResponse {
+  'body' : Uint8Array | number[],
+  'headers' : Array<HeaderField>,
+  'status_code' : number,
+}
+export interface Icrc21ConsentInfo {
+  'consent_message' : string,
+  'language' : string,
+}
+export interface Icrc21ConsentPreferences { 'language' : string }
+export type Icrc21Error = {
+    'GenericError' : { 'description' : string, 'error_code' : bigint }
+  } |
+  { 'UnsupportedCanisterCall' : Icrc21ErrorInfo } |
+  { 'ConsentMessageUnavailable' : Icrc21ErrorInfo };
+export interface Icrc21ErrorInfo { 'description' : string }
+export interface Icrc21VcConsentMessageRequest {
+  'preferences' : Icrc21ConsentPreferences,
+  'credential_spec' : CredentialSpec,
+}
+export type IssueCredentialError = { 'Internal' : string } |
+  { 'SignatureNotFound' : string } |
+  { 'InvalidIdAlias' : string } |
+  { 'UnauthorizedSubject' : string } |
+  { 'UnknownSubject' : string } |
+  { 'UnsupportedCredentialSpec' : string };
+export interface IssuedCredentialData { 'vc_jws' : string }
+export interface IssuerConfig {
+  'idp_canister_ids' : Array<Principal>,
+  'ic_root_key_der' : Uint8Array | number[],
+}
+export interface PrepareCredentialRequest {
+  'signed_id_alias' : SignedIdAlias,
+  'credential_spec' : CredentialSpec,
+}
+export interface PreparedCredentialData {
+  'prepared_context' : [] | [Uint8Array | number[]],
+}
+export interface SignedIdAlias { 'credential_jws' : string }
+export interface _SERVICE {
+  'configure' : ActorMethod<[IssuerConfig], undefined>,
+  'get_credential' : ActorMethod<
+    [GetCredentialRequest],
+    { 'Ok' : IssuedCredentialData } |
+      { 'Err' : IssueCredentialError }
+  >,
+  'http_request' : ActorMethod<[HttpRequest], HttpResponse>,
+  'prepare_credential' : ActorMethod<
+    [PrepareCredentialRequest],
+    { 'Ok' : PreparedCredentialData } |
+      { 'Err' : IssueCredentialError }
+  >,
+  'register_early_adopter' : ActorMethod<
+    [],
+    { 'Ok' : EarlyAdopterStatus } |
+      { 'Err' : EarlyAdopterError }
+  >,
+  'vc_consent_message' : ActorMethod<
+    [Icrc21VcConsentMessageRequest],
+    { 'Ok' : Icrc21ConsentInfo } |
+      { 'Err' : Icrc21Error }
+  >,
+}

--- a/frontend/src/declarations/early_adopter/early_adopter.did.js
+++ b/frontend/src/declarations/early_adopter/early_adopter.did.js
@@ -1,0 +1,107 @@
+export const idlFactory = ({ IDL }) => {
+  const IssuerConfig = IDL.Record({
+    'idp_canister_ids' : IDL.Vec(IDL.Principal),
+    'ic_root_key_der' : IDL.Vec(IDL.Nat8),
+  });
+  const SignedIdAlias = IDL.Record({ 'credential_jws' : IDL.Text });
+  const ArgumentValue = IDL.Variant({ 'Int' : IDL.Int32, 'String' : IDL.Text });
+  const CredentialSpec = IDL.Record({
+    'arguments' : IDL.Opt(IDL.Vec(IDL.Tuple(IDL.Text, ArgumentValue))),
+    'credential_type' : IDL.Text,
+  });
+  const GetCredentialRequest = IDL.Record({
+    'signed_id_alias' : SignedIdAlias,
+    'prepared_context' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'credential_spec' : CredentialSpec,
+  });
+  const IssuedCredentialData = IDL.Record({ 'vc_jws' : IDL.Text });
+  const IssueCredentialError = IDL.Variant({
+    'Internal' : IDL.Text,
+    'SignatureNotFound' : IDL.Text,
+    'InvalidIdAlias' : IDL.Text,
+    'UnauthorizedSubject' : IDL.Text,
+    'UnknownSubject' : IDL.Text,
+    'UnsupportedCredentialSpec' : IDL.Text,
+  });
+  const HeaderField = IDL.Tuple(IDL.Text, IDL.Text);
+  const HttpRequest = IDL.Record({
+    'url' : IDL.Text,
+    'method' : IDL.Text,
+    'body' : IDL.Vec(IDL.Nat8),
+    'headers' : IDL.Vec(HeaderField),
+    'certificate_version' : IDL.Opt(IDL.Nat16),
+  });
+  const HttpResponse = IDL.Record({
+    'body' : IDL.Vec(IDL.Nat8),
+    'headers' : IDL.Vec(HeaderField),
+    'status_code' : IDL.Nat16,
+  });
+  const PrepareCredentialRequest = IDL.Record({
+    'signed_id_alias' : SignedIdAlias,
+    'credential_spec' : CredentialSpec,
+  });
+  const PreparedCredentialData = IDL.Record({
+    'prepared_context' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+  });
+  const EarlyAdopterStatus = IDL.Record({ 'joined_timestamp_s' : IDL.Nat32 });
+  const EarlyAdopterError = IDL.Variant({ 'Internal' : IDL.Text });
+  const Icrc21ConsentPreferences = IDL.Record({ 'language' : IDL.Text });
+  const Icrc21VcConsentMessageRequest = IDL.Record({
+    'preferences' : Icrc21ConsentPreferences,
+    'credential_spec' : CredentialSpec,
+  });
+  const Icrc21ConsentInfo = IDL.Record({
+    'consent_message' : IDL.Text,
+    'language' : IDL.Text,
+  });
+  const Icrc21ErrorInfo = IDL.Record({ 'description' : IDL.Text });
+  const Icrc21Error = IDL.Variant({
+    'GenericError' : IDL.Record({
+      'description' : IDL.Text,
+      'error_code' : IDL.Nat,
+    }),
+    'UnsupportedCanisterCall' : Icrc21ErrorInfo,
+    'ConsentMessageUnavailable' : Icrc21ErrorInfo,
+  });
+  return IDL.Service({
+    'configure' : IDL.Func([IssuerConfig], [], []),
+    'get_credential' : IDL.Func(
+        [GetCredentialRequest],
+        [
+          IDL.Variant({
+            'Ok' : IssuedCredentialData,
+            'Err' : IssueCredentialError,
+          }),
+        ],
+        ['query'],
+      ),
+    'http_request' : IDL.Func([HttpRequest], [HttpResponse], ['query']),
+    'prepare_credential' : IDL.Func(
+        [PrepareCredentialRequest],
+        [
+          IDL.Variant({
+            'Ok' : PreparedCredentialData,
+            'Err' : IssueCredentialError,
+          }),
+        ],
+        [],
+      ),
+    'register_early_adopter' : IDL.Func(
+        [],
+        [IDL.Variant({ 'Ok' : EarlyAdopterStatus, 'Err' : EarlyAdopterError })],
+        [],
+      ),
+    'vc_consent_message' : IDL.Func(
+        [Icrc21VcConsentMessageRequest],
+        [IDL.Variant({ 'Ok' : Icrc21ConsentInfo, 'Err' : Icrc21Error })],
+        [],
+      ),
+  });
+};
+export const init = ({ IDL }) => {
+  const IssuerConfig = IDL.Record({
+    'idp_canister_ids' : IDL.Vec(IDL.Principal),
+    'ic_root_key_der' : IDL.Vec(IDL.Nat8),
+  });
+  return [IDL.Opt(IssuerConfig)];
+};

--- a/frontend/src/declarations/early_adopter/index.d.ts
+++ b/frontend/src/declarations/early_adopter/index.d.ts
@@ -1,0 +1,50 @@
+import type {
+  ActorSubclass,
+  HttpAgentOptions,
+  ActorConfig,
+  Agent,
+} from "@dfinity/agent";
+import type { Principal } from "@dfinity/principal";
+import type { IDL } from "@dfinity/candid";
+
+import { _SERVICE } from './early_adopter.did';
+
+export declare const idlFactory: IDL.InterfaceFactory;
+export declare const canisterId: string;
+
+export declare interface CreateActorOptions {
+  /**
+   * @see {@link Agent}
+   */
+  agent?: Agent;
+  /**
+   * @see {@link HttpAgentOptions}
+   */
+  agentOptions?: HttpAgentOptions;
+  /**
+   * @see {@link ActorConfig}
+   */
+  actorOptions?: ActorConfig;
+}
+
+/**
+ * Intializes an {@link ActorSubclass}, configured with the provided SERVICE interface of a canister.
+ * @constructs {@link ActorSubClass}
+ * @param {string | Principal} canisterId - ID of the canister the {@link Actor} will talk to
+ * @param {CreateActorOptions} options - see {@link CreateActorOptions}
+ * @param {CreateActorOptions["agent"]} options.agent - a pre-configured agent you'd like to use. Supercedes agentOptions
+ * @param {CreateActorOptions["agentOptions"]} options.agentOptions - options to set up a new agent
+ * @see {@link HttpAgentOptions}
+ * @param {CreateActorOptions["actorOptions"]} options.actorOptions - options for the Actor
+ * @see {@link ActorConfig}
+ */
+export declare const createActor: (
+  canisterId: string | Principal,
+  options?: CreateActorOptions
+) => ActorSubclass<_SERVICE>;
+
+/**
+ * Intialized Actor using default settings, ready to talk to a canister using its candid interface
+ * @constructs {@link ActorSubClass}
+ */
+export declare const early_adopter: ActorSubclass<_SERVICE>;

--- a/frontend/src/declarations/early_adopter/index.js
+++ b/frontend/src/declarations/early_adopter/index.js
@@ -1,0 +1,2 @@
+export { idlFactory } from "./early_adopter.did.js";
+

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -42,22 +42,8 @@ import ToastError from "../components/ToastError.astro";
 
 <script>
   import { AuthClient } from "@dfinity/auth-client";
-  import { Actor, HttpAgent, type ActorMethod } from "@dfinity/agent";
-
-  type RegisterEarlyAdopterResponse =
-    | { Ok: { joined_timestamp_s: number } }
-    | { Err: { Internal: string }}
-  
-  // @ts-ignore - The interface of the whoami canister
-  const webapp_idl = ({ IDL }) => {
-    const EarlyAdopterStatus = IDL.Record({ 'joined_timestamp_s' : IDL.Nat32 });
-    const EarlyAdopterError = IDL.Variant({ 'Internal' : IDL.Text });
-    return IDL.Service({ register_early_adopter: IDL.Func([], [IDL.Variant({ 'Ok' : EarlyAdopterStatus, 'Err' : EarlyAdopterError })], []) });
-  };
-
-  export interface _SERVICE {
-    register_early_adopter: ActorMethod<[], RegisterEarlyAdopterResponse>;
-  }
+  import { HttpAgent } from "@dfinity/agent";
+  import { createActor } from "../utils/actor";
 
   const AUTH_POPUP_WIDTH = 576;
   const AUTH_POPUP_HEIGHT = 625;
@@ -89,25 +75,19 @@ import ToastError from "../components/ToastError.astro";
   const mainAppElement = document.querySelector("[data-app]") as HTMLElement;
   const canisterId = mainAppElement.dataset.canisterId ?? import.meta.env.PUBLIC_OWN_CANISTER_ID;
   const fetchRootKey = import.meta.env.PUBLIC_FETCH_ROOT_KEY === "true";
-
+  
   const busyScreen = document.getElementById('busy') as HTMLDivElement;
-
+  
   const login = () => {
     return new Promise((resolve) => {
       busyScreen.classList.remove('hide');
-
+      
       authClient.login({
         onSuccess: async () => {
           try {
             const identity = authClient.getIdentity();
             const agent = new HttpAgent({ identity, host });
-            if (fetchRootKey) {
-              await agent.fetchRootKey();
-            }
-            const webapp: _SERVICE = Actor.createActor(webapp_idl, {
-              agent,
-              canisterId,
-            });
+            const webapp = await createActor({ canisterId, agent, fetchRootKey})
             const registerResponse = await webapp.register_early_adopter();
             if ("Ok" in registerResponse) {
               resolve({ status: 200, message: 'Logged in successfully!' });

--- a/frontend/src/utils/actor.ts
+++ b/frontend/src/utils/actor.ts
@@ -1,0 +1,27 @@
+import { Actor, HttpAgent, type ActorSubclass } from "@dfinity/agent";
+import { idlFactory } from "../declarations/early_adopter";
+import type { _SERVICE } from '../declarations/early_adopter/early_adopter.did';
+
+
+export const createActor = async (
+  { canisterId, agent, fetchRootKey }:
+  { canisterId: string, agent: HttpAgent, fetchRootKey: boolean }
+): Promise<ActorSubclass<_SERVICE>> => {
+  // Fetch root key for certificate validation during development
+  if (fetchRootKey) {
+    try {
+      await agent.fetchRootKey()
+    } catch (err) {
+      console.warn(
+        "Unable to fetch root key. Check to ensure that your local replica is running"
+      );
+      console.error(err);
+    }
+  }
+
+  // Creates an actor with using the candid interface and the HttpAgent
+  return Actor.createActor<_SERVICE>(idlFactory, {
+    agent,
+    canisterId,
+  });
+};


### PR DESCRIPTION
At the moment, the actor was created inline without using the candid file directly. But if we are going to add more endpoints, it makes sense to generate it automatically.

In this PR, I remove the inline creation and instead generate the file from candid with `dfx generate`. I also add some custom code to adapt the our environment.