### PR TITLE
Add derivation_origin-endpoint

### DIFF
--- a/early_adopter_issuer.did
+++ b/early_adopter_issuer.did
@@ -70,12 +70,26 @@ type IssueCredentialError = variant {
     Internal : text;
 };
 
+/// Types for `derivation_origin`.
+type DerivationOriginRequest = record {
+    frontend_hostname : text;
+};
+type DerivationOriginData = record { origin : text };
+type DerivationOriginError = variant {
+  Internal : text;
+  UnsupportedOrigin : text;
+};
+
 /// Configuration specific to this issuer.
 type IssuerConfig = record {
     /// Root of trust for checking canister signatures.
     ic_root_key_der : blob;
     /// List of canister ids that are allowed to provide id alias credentials.
     idp_canister_ids : vec principal;
+    /// The derivation origin to be used by the issuer.
+    derivation_origin : text;
+    /// Frontend hostname be used by the issuer.
+    frontend_hostname : text;
 };
 
 /// Options related to HTTP handling
@@ -104,6 +118,7 @@ service: (opt IssuerConfig) -> {
     vc_consent_message : (Icrc21VcConsentMessageRequest) -> (variant { Ok : Icrc21ConsentInfo; Err : Icrc21Error });
     prepare_credential : (PrepareCredentialRequest) -> (variant { Ok : PreparedCredentialData; Err : IssueCredentialError });
     get_credential : (GetCredentialRequest) -> (variant { Ok : IssuedCredentialData; Err : IssueCredentialError }) query;
+    derivation_origin : (DerivationOriginRequest) -> (variant {Ok: DerivationOriginData; Err: DerivationOriginError});
 
     /// Configure the issuer (e.g. set the root key), used for deployment/testing.
     configure: (IssuerConfig) -> ();

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,9 @@ use sha2::{Digest, Sha256};
 use std::borrow::Cow;
 use std::cell::RefCell;
 use vc_util::issuer_api::{
-    ArgumentValue, CredentialSpec, GetCredentialRequest, Icrc21ConsentInfo, Icrc21Error,
-    Icrc21ErrorInfo, Icrc21VcConsentMessageRequest, IssueCredentialError, IssuedCredentialData,
+    ArgumentValue, CredentialSpec, DerivationOriginData, DerivationOriginError,
+    DerivationOriginRequest, GetCredentialRequest, Icrc21ConsentInfo, Icrc21Error, Icrc21ErrorInfo,
+    Icrc21VcConsentMessageRequest, IssueCredentialError, IssuedCredentialData,
     PrepareCredentialRequest, PreparedCredentialData, SignedIdAlias,
 };
 use vc_util::{
@@ -122,6 +123,10 @@ struct IssuerConfig {
     ic_root_key_raw: Vec<u8>,
     /// List of canister ids that are allowed to provide id alias credentials.
     idp_canister_ids: Vec<Principal>,
+    /// The derivation origin to be used by the issuer.
+    derivation_origin: String,
+    /// Frontend hostname to be used by the issuer.
+    frontend_hostname: String,
 }
 
 impl Storable for IssuerConfig {
@@ -136,10 +141,13 @@ impl Storable for IssuerConfig {
 
 impl Default for IssuerConfig {
     fn default() -> Self {
+        let derivation_origin = format!("https://{}.icp0.io", ic_cdk::id().to_text());
         Self {
             ic_root_key_raw: extract_raw_root_pk_from_der(IC_ROOT_PK_DER)
                 .expect("failed to extract raw root pk from der"),
             idp_canister_ids: vec![Principal::from_text(PROD_II_CANISTER_ID).unwrap()],
+            derivation_origin: derivation_origin.clone(),
+            frontend_hostname: derivation_origin, // by default, use DERIVATION_ORIGIN as frontend-hostname
         }
     }
 }
@@ -150,6 +158,8 @@ impl From<IssuerInit> for IssuerConfig {
             ic_root_key_raw: extract_raw_root_pk_from_der(&init.ic_root_key_der)
                 .expect("failed to extract raw root pk from der"),
             idp_canister_ids: init.idp_canister_ids,
+            derivation_origin: init.derivation_origin,
+            frontend_hostname: init.frontend_hostname,
         }
     }
 }
@@ -160,6 +170,10 @@ struct IssuerInit {
     ic_root_key_der: Vec<u8>,
     /// List of canister ids that are allowed to provide id alias credentials.
     idp_canister_ids: Vec<Principal>,
+    /// The derivation origin to be used by the issuer.
+    derivation_origin: String,
+    /// Frontend hostname to be used by the issuer.
+    frontend_hostname: String,
 }
 
 #[init]
@@ -318,6 +332,29 @@ async fn vc_consent_message(
     req: Icrc21VcConsentMessageRequest,
 ) -> Result<Icrc21ConsentInfo, Icrc21Error> {
     get_vc_consent_message_en(&req.credential_spec)
+}
+
+#[update]
+#[candid_method]
+async fn derivation_origin(
+    req: DerivationOriginRequest,
+) -> Result<DerivationOriginData, DerivationOriginError> {
+    get_derivation_origin(&req.frontend_hostname)
+}
+
+fn get_derivation_origin(hostname: &str) -> Result<DerivationOriginData, DerivationOriginError> {
+    CONFIG.with_borrow(|config| {
+        let config = config.get();
+        if hostname == config.frontend_hostname {
+            Ok(DerivationOriginData {
+                origin: config.derivation_origin.clone(),
+            })
+        } else {
+            Err(DerivationOriginError::UnsupportedOrigin(
+                hostname.to_string(),
+            ))
+        }
+    })
 }
 
 const EARLY_ADOPTER_VC_CONSENT_EN: &str = r###"# Verifiable Credentials Early Adopter


### PR DESCRIPTION
Add `derivation_origin`-API to the issuer (cf. [spec](https://github.com/dfinity/internet-identity/blob/main/docs/vc-spec.md#2-derivation-origin-optional))