### PR TITLE
Add events with Code

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Deploy canisters
       run: dfx deploy --no-wallet --network local
     - name: Create Event
-      run: dfx canister call early_adopter register_event '(record { event_name = "TEST"; registration_code = opt "testcode" })'
+      run: dfx canister call early_adopter add_event '(record { event_name = "TEST"; registration_code = opt "testcode" })'
     - name: Run Playwright tests
       working-directory: frontend
       run: PLAYWRIGHT_BASE_URL=http:/$(dfx canister id early_adopter).localhost:$(dfx info webserver-port) npm run test:e2e

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Deploy canisters
       run: dfx deploy --no-wallet --network local
     - name: Create Event
-      run: dfx canister call early_adopter register_event '(record { event_name = "TEST"; code = opt "testcode" })'
+      run: dfx canister call early_adopter register_event '(record { event_name = "TEST"; registration_code = opt "testcode" })'
     - name: Run Playwright tests
       working-directory: frontend
       run: PLAYWRIGHT_BASE_URL=http:/$(dfx canister id early_adopter).localhost:$(dfx info webserver-port) npm run test:e2e

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -34,6 +34,8 @@ jobs:
       run: DFX_NETWORK=local ./scripts/create-env-vars.sh
     - name: Deploy canisters
       run: dfx deploy --no-wallet --network local
+    - name: Create Event
+      run: dfx canister call early_adopter register_event '(record { event_name = "TEST"; code = opt "testcode" })'
     - name: Run Playwright tests
       working-directory: frontend
       run: PLAYWRIGHT_BASE_URL=http:/$(dfx canister id early_adopter).localhost:$(dfx info webserver-port) npm run test:e2e

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An implementation of a Verified Credentials issuer for "EventAttendance" credent
 
 Before building the wasm you need to specify the environment variables of the context you are building.
 
-There is a script that reads the canister ids and local replica to create the env vars: `DFX_NETWORK=local ./scripts/create-env-vars.sh`.
+There is a script within the `frontend` directory that reads the canister ids and local replica to create the env vars: `DFX_NETWORK=local ./scripts/create-env-vars.sh`.
 
 The `DFX_NETWORK=local` is needed to get the canister ids from the dfx replica.
 

--- a/early_adopter_issuer.did
+++ b/early_adopter_issuer.did
@@ -10,15 +10,15 @@ type CredentialSpec = record {
     arguments : opt vec record { text; ArgumentValue };
 };
 type ArgumentValue = variant { "Int" : int32; String : text };
-type EventData = record {
+type UserEventData = record {
     event_name : text;
     joined_timestamp_s : nat32;
 };
 type EarlyAdopterResponse = record {
     joined_timestamp_s : nat32;
-    events : vec EventData;
+    events : vec UserEventData;
 };
-type EarlyAdopterError = variant {
+type RegisterError = variant {
     Internal : text;
     External : text;
 };
@@ -124,8 +124,29 @@ type HttpResponse = record {
 };
 
 type RegisterRequest = record {
-    event_name: opt text;
-}
+    event_name: text;
+    code: text;
+};
+
+type RegisterEventRequest = record {
+    event_name: text;
+};
+
+type RegisterEventResponse = record {
+    event_name: text;
+    created_timestamp_s: nat32;
+    code: text;
+};
+
+type EventData = record {
+    event_name: text;
+    created_timestamp_s: nat32;
+    code: opt text;
+};
+
+type ListEventsResponse = record {
+    events: vec EventData;
+};
 
 service: (opt IssuerConfig) -> {
     /// VC-flow API.
@@ -138,7 +159,9 @@ service: (opt IssuerConfig) -> {
     configure: (IssuerConfig) -> ();
 
     /// Register a user as an early adopter.
-    register_early_adopter : (RegisterRequest) ->  (variant { Ok : EarlyAdopterResponse; Err : EarlyAdopterError });
+    register_early_adopter : (RegisterRequest) ->  (variant { Ok : EarlyAdopterResponse; Err : RegisterError });
+    register_event : (RegisterEventRequest) -> (variant { Ok : RegisterEventResponse; Err : RegisterError });
+    list_events : () -> (ListEventsResponse) query;
 
     /// Serve the app
     http_request: (request: HttpRequest) -> (HttpResponse) query;

--- a/early_adopter_issuer.did
+++ b/early_adopter_issuer.did
@@ -123,30 +123,30 @@ type HttpResponse = record {
     body: blob;
 };
 
-type RegisterEventData = record {
+type RegisterUserEventData = record {
     event_name: text;
-    code: text;
+    registration_code: text;
 };
 
-type RegisterRequest = record {
-    event_data: opt RegisterEventData;
+type RegisterUserRequest = record {
+    event_data: opt RegisterUserEventData;
 };
 
-type RegisterEventRequest = record {
+type AddEventRequest = record {
     event_name: text;
-    code: opt text;
+    registration_code: opt text;
 };
 
-type RegisterEventResponse = record {
+type AddEventResponse = record {
     event_name: text;
     created_timestamp_s: nat32;
-    code: text;
+    registration_code: text;
 };
 
 type EventRecord = record {
     event_name: text;
     created_timestamp_s: nat32;
-    code: opt text;
+    registration_code: opt text;
 };
 
 type ListEventsResponse = record {
@@ -164,8 +164,8 @@ service: (opt IssuerConfig) -> {
     configure: (IssuerConfig) -> ();
 
     /// Register a user as an early adopter.
-    register_early_adopter : (RegisterRequest) ->  (variant { Ok : EarlyAdopterResponse; Err : RegisterError });
-    register_event : (RegisterEventRequest) -> (variant { Ok : RegisterEventResponse; Err : RegisterError });
+    register_early_adopter : (RegisterUserRequest) ->  (variant { Ok : EarlyAdopterResponse; Err : RegisterError });
+    add_event : (AddEventRequest) -> (variant { Ok : AddEventResponse; Err : RegisterError });
     list_events : () -> (variant { Ok : ListEventsResponse; Err : RegisterError });
 
     /// Serve the app

--- a/early_adopter_issuer.did
+++ b/early_adopter_issuer.did
@@ -166,7 +166,7 @@ service: (opt IssuerConfig) -> {
     /// Register a user as an early adopter.
     register_early_adopter : (RegisterRequest) ->  (variant { Ok : EarlyAdopterResponse; Err : RegisterError });
     register_event : (RegisterEventRequest) -> (variant { Ok : RegisterEventResponse; Err : RegisterError });
-    list_events : () -> (variant { Ok : ListEventsResponse; Err : RegisterError }) query;
+    list_events : () -> (variant { Ok : ListEventsResponse; Err : RegisterError });
 
     /// Serve the app
     http_request: (request: HttpRequest) -> (HttpResponse) query;

--- a/early_adopter_issuer.did
+++ b/early_adopter_issuer.did
@@ -166,7 +166,7 @@ service: (opt IssuerConfig) -> {
     /// Register a user as an early adopter.
     register_early_adopter : (RegisterRequest) ->  (variant { Ok : EarlyAdopterResponse; Err : RegisterError });
     register_event : (RegisterEventRequest) -> (variant { Ok : RegisterEventResponse; Err : RegisterError });
-    list_events : () -> (ListEventsResponse) query;
+    list_events : () -> (variant { Ok : ListEventsResponse; Err : RegisterError }) query;
 
     /// Serve the app
     http_request: (request: HttpRequest) -> (HttpResponse) query;

--- a/early_adopter_issuer.did
+++ b/early_adopter_issuer.did
@@ -134,6 +134,7 @@ type RegisterRequest = record {
 
 type RegisterEventRequest = record {
     event_name: text;
+    code: opt text;
 };
 
 type RegisterEventResponse = record {

--- a/early_adopter_issuer.did
+++ b/early_adopter_issuer.did
@@ -123,9 +123,13 @@ type HttpResponse = record {
     body: blob;
 };
 
-type RegisterRequest = record {
+type RegisterEventData = record {
     event_name: text;
     code: text;
+};
+
+type RegisterRequest = record {
+    event_data: opt RegisterEventData;
 };
 
 type RegisterEventRequest = record {
@@ -138,14 +142,14 @@ type RegisterEventResponse = record {
     code: text;
 };
 
-type EventData = record {
+type EventRecord = record {
     event_name: text;
     created_timestamp_s: nat32;
     code: opt text;
 };
 
 type ListEventsResponse = record {
-    events: vec EventData;
+    events: vec EventRecord;
 };
 
 service: (opt IssuerConfig) -> {

--- a/frontend/e2e-tests/registration.spec.ts
+++ b/frontend/e2e-tests/registration.spec.ts
@@ -1,8 +1,9 @@
 import { test, expect } from '@playwright/test';
 import { signInWithNewUser } from './utils';
 
+// Needs to match the event created in the backend.
 const eventName = "TEST";
-const eventCode = "TESTCODE"
+const eventCode = "testcode"
 
 test("use registers with Internet Identity and is redirected to a success page", async ({ page, context }) => {
   await page.goto(`/?e=${eventName}&c=${eventCode}`);

--- a/frontend/e2e-tests/registration.spec.ts
+++ b/frontend/e2e-tests/registration.spec.ts
@@ -1,8 +1,11 @@
 import { test, expect } from '@playwright/test';
 import { signInWithNewUser } from './utils';
 
+const eventName = "TEST";
+const eventCode = "TESTCODE"
+
 test("use registers with Internet Identity and is redirected to a success page", async ({ page, context }) => {
-  await page.goto('/');
+  await page.goto(`/?e=${eventName}&c=${eventCode}`);
   await expect(page).toHaveTitle(/Proof of Attendance Campaign/);
 
   await signInWithNewUser({ page, context });

--- a/frontend/src/declarations/early_adopter/early_adopter.did
+++ b/frontend/src/declarations/early_adopter/early_adopter.did
@@ -10,15 +10,15 @@ type CredentialSpec = record {
     arguments : opt vec record { text; ArgumentValue };
 };
 type ArgumentValue = variant { "Int" : int32; String : text };
-type EventData = record {
+type UserEventData = record {
     event_name : text;
     joined_timestamp_s : nat32;
 };
 type EarlyAdopterResponse = record {
     joined_timestamp_s : nat32;
-    events : vec EventData;
+    events : vec UserEventData;
 };
-type EarlyAdopterError = variant {
+type RegisterError = variant {
     Internal : text;
     External : text;
 };
@@ -124,8 +124,29 @@ type HttpResponse = record {
 };
 
 type RegisterRequest = record {
-    event_name: opt text;
-}
+    event_name: text;
+    code: text;
+};
+
+type RegisterEventRequest = record {
+    event_name: text;
+};
+
+type RegisterEventResponse = record {
+    event_name: text;
+    created_timestamp_s: nat32;
+    code: text;
+};
+
+type EventData = record {
+    event_name: text;
+    created_timestamp_s: nat32;
+    code: opt text;
+};
+
+type ListEventsResponse = record {
+    events: vec EventData;
+};
 
 service: (opt IssuerConfig) -> {
     /// VC-flow API.
@@ -138,7 +159,9 @@ service: (opt IssuerConfig) -> {
     configure: (IssuerConfig) -> ();
 
     /// Register a user as an early adopter.
-    register_early_adopter : (RegisterRequest) ->  (variant { Ok : EarlyAdopterResponse; Err : EarlyAdopterError });
+    register_early_adopter : (RegisterRequest) ->  (variant { Ok : EarlyAdopterResponse; Err : RegisterError });
+    register_event : (RegisterEventRequest) -> (variant { Ok : RegisterEventResponse; Err : RegisterError });
+    list_events : () -> (ListEventsResponse) query;
 
     /// Serve the app
     http_request: (request: HttpRequest) -> (HttpResponse) query;

--- a/frontend/src/declarations/early_adopter/early_adopter.did
+++ b/frontend/src/declarations/early_adopter/early_adopter.did
@@ -123,30 +123,30 @@ type HttpResponse = record {
     body: blob;
 };
 
-type RegisterEventData = record {
+type RegisterUserEventData = record {
     event_name: text;
-    code: text;
+    registration_code: text;
 };
 
-type RegisterRequest = record {
-    event_data: opt RegisterEventData;
+type RegisterUserRequest = record {
+    event_data: opt RegisterUserEventData;
 };
 
-type RegisterEventRequest = record {
+type AddEventRequest = record {
     event_name: text;
-    code: opt text;
+    registration_code: opt text;
 };
 
-type RegisterEventResponse = record {
+type AddEventResponse = record {
     event_name: text;
     created_timestamp_s: nat32;
-    code: text;
+    registration_code: text;
 };
 
 type EventRecord = record {
     event_name: text;
     created_timestamp_s: nat32;
-    code: opt text;
+    registration_code: opt text;
 };
 
 type ListEventsResponse = record {
@@ -164,8 +164,8 @@ service: (opt IssuerConfig) -> {
     configure: (IssuerConfig) -> ();
 
     /// Register a user as an early adopter.
-    register_early_adopter : (RegisterRequest) ->  (variant { Ok : EarlyAdopterResponse; Err : RegisterError });
-    register_event : (RegisterEventRequest) -> (variant { Ok : RegisterEventResponse; Err : RegisterError });
+    register_early_adopter : (RegisterUserRequest) ->  (variant { Ok : EarlyAdopterResponse; Err : RegisterError });
+    add_event : (AddEventRequest) -> (variant { Ok : AddEventResponse; Err : RegisterError });
     list_events : () -> (variant { Ok : ListEventsResponse; Err : RegisterError });
 
     /// Serve the app

--- a/frontend/src/declarations/early_adopter/early_adopter.did
+++ b/frontend/src/declarations/early_adopter/early_adopter.did
@@ -166,7 +166,7 @@ service: (opt IssuerConfig) -> {
     /// Register a user as an early adopter.
     register_early_adopter : (RegisterRequest) ->  (variant { Ok : EarlyAdopterResponse; Err : RegisterError });
     register_event : (RegisterEventRequest) -> (variant { Ok : RegisterEventResponse; Err : RegisterError });
-    list_events : () -> (variant { Ok : ListEventsResponse; Err : RegisterError }) query;
+    list_events : () -> (variant { Ok : ListEventsResponse; Err : RegisterError });
 
     /// Serve the app
     http_request: (request: HttpRequest) -> (HttpResponse) query;

--- a/frontend/src/declarations/early_adopter/early_adopter.did
+++ b/frontend/src/declarations/early_adopter/early_adopter.did
@@ -166,7 +166,7 @@ service: (opt IssuerConfig) -> {
     /// Register a user as an early adopter.
     register_early_adopter : (RegisterRequest) ->  (variant { Ok : EarlyAdopterResponse; Err : RegisterError });
     register_event : (RegisterEventRequest) -> (variant { Ok : RegisterEventResponse; Err : RegisterError });
-    list_events : () -> (ListEventsResponse) query;
+    list_events : () -> (variant { Ok : ListEventsResponse; Err : RegisterError }) query;
 
     /// Serve the app
     http_request: (request: HttpRequest) -> (HttpResponse) query;

--- a/frontend/src/declarations/early_adopter/early_adopter.did
+++ b/frontend/src/declarations/early_adopter/early_adopter.did
@@ -134,6 +134,7 @@ type RegisterRequest = record {
 
 type RegisterEventRequest = record {
     event_name: text;
+    code: opt text;
 };
 
 type RegisterEventResponse = record {

--- a/frontend/src/declarations/early_adopter/early_adopter.did
+++ b/frontend/src/declarations/early_adopter/early_adopter.did
@@ -123,9 +123,13 @@ type HttpResponse = record {
     body: blob;
 };
 
-type RegisterRequest = record {
+type RegisterEventData = record {
     event_name: text;
     code: text;
+};
+
+type RegisterRequest = record {
+    event_data: opt RegisterEventData;
 };
 
 type RegisterEventRequest = record {
@@ -138,14 +142,14 @@ type RegisterEventResponse = record {
     code: text;
 };
 
-type EventData = record {
+type EventRecord = record {
     event_name: text;
     created_timestamp_s: nat32;
     code: opt text;
 };
 
 type ListEventsResponse = record {
-    events: vec EventData;
+    events: vec EventRecord;
 };
 
 service: (opt IssuerConfig) -> {

--- a/frontend/src/declarations/early_adopter/early_adopter.did.d.ts
+++ b/frontend/src/declarations/early_adopter/early_adopter.did.d.ts
@@ -1,6 +1,15 @@
 import type { Principal } from '@dfinity/principal';
 import type { ActorMethod } from '@dfinity/agent';
 
+export interface AddEventRequest {
+  'registration_code' : [] | [string],
+  'event_name' : string,
+}
+export interface AddEventResponse {
+  'registration_code' : string,
+  'created_timestamp_s' : number,
+  'event_name' : string,
+}
 export type ArgumentValue = { 'Int' : number } |
   { 'String' : string };
 export interface CredentialSpec {
@@ -16,8 +25,8 @@ export interface EarlyAdopterResponse {
   'events' : Array<UserEventData>,
 }
 export interface EventRecord {
+  'registration_code' : [] | [string],
   'created_timestamp_s' : number,
-  'code' : [] | [string],
   'event_name' : string,
 }
 export interface GetCredentialRequest {
@@ -76,23 +85,24 @@ export interface PreparedCredentialData {
 }
 export type RegisterError = { 'Internal' : string } |
   { 'External' : string };
-export interface RegisterEventData { 'code' : string, 'event_name' : string }
-export interface RegisterEventRequest {
-  'code' : [] | [string],
+export interface RegisterUserEventData {
+  'registration_code' : string,
   'event_name' : string,
 }
-export interface RegisterEventResponse {
-  'created_timestamp_s' : number,
-  'code' : string,
-  'event_name' : string,
+export interface RegisterUserRequest {
+  'event_data' : [] | [RegisterUserEventData],
 }
-export interface RegisterRequest { 'event_data' : [] | [RegisterEventData] }
 export interface SignedIdAlias { 'credential_jws' : string }
 export interface UserEventData {
   'joined_timestamp_s' : number,
   'event_name' : string,
 }
 export interface _SERVICE {
+  'add_event' : ActorMethod<
+    [AddEventRequest],
+    { 'Ok' : AddEventResponse } |
+      { 'Err' : RegisterError }
+  >,
   'configure' : ActorMethod<[IssuerConfig], undefined>,
   'derivation_origin' : ActorMethod<
     [DerivationOriginRequest],
@@ -116,13 +126,8 @@ export interface _SERVICE {
       { 'Err' : IssueCredentialError }
   >,
   'register_early_adopter' : ActorMethod<
-    [RegisterRequest],
+    [RegisterUserRequest],
     { 'Ok' : EarlyAdopterResponse } |
-      { 'Err' : RegisterError }
-  >,
-  'register_event' : ActorMethod<
-    [RegisterEventRequest],
-    { 'Ok' : RegisterEventResponse } |
       { 'Err' : RegisterError }
   >,
   'vc_consent_message' : ActorMethod<

--- a/frontend/src/declarations/early_adopter/early_adopter.did.d.ts
+++ b/frontend/src/declarations/early_adopter/early_adopter.did.d.ts
@@ -105,7 +105,11 @@ export interface _SERVICE {
       { 'Err' : IssueCredentialError }
   >,
   'http_request' : ActorMethod<[HttpRequest], HttpResponse>,
-  'list_events' : ActorMethod<[], ListEventsResponse>,
+  'list_events' : ActorMethod<
+    [],
+    { 'Ok' : ListEventsResponse } |
+      { 'Err' : RegisterError }
+  >,
   'prepare_credential' : ActorMethod<
     [PrepareCredentialRequest],
     { 'Ok' : PreparedCredentialData } |

--- a/frontend/src/declarations/early_adopter/early_adopter.did.d.ts
+++ b/frontend/src/declarations/early_adopter/early_adopter.did.d.ts
@@ -15,7 +15,7 @@ export interface EarlyAdopterResponse {
   'joined_timestamp_s' : number,
   'events' : Array<UserEventData>,
 }
-export interface EventData {
+export interface EventRecord {
   'created_timestamp_s' : number,
   'code' : [] | [string],
   'event_name' : string,
@@ -66,7 +66,7 @@ export interface IssuerConfig {
   'ic_root_key_der' : Uint8Array | number[],
   'frontend_hostname' : string,
 }
-export interface ListEventsResponse { 'events' : Array<EventData> }
+export interface ListEventsResponse { 'events' : Array<EventRecord> }
 export interface PrepareCredentialRequest {
   'signed_id_alias' : SignedIdAlias,
   'credential_spec' : CredentialSpec,
@@ -76,13 +76,14 @@ export interface PreparedCredentialData {
 }
 export type RegisterError = { 'Internal' : string } |
   { 'External' : string };
+export interface RegisterEventData { 'code' : string, 'event_name' : string }
 export interface RegisterEventRequest { 'event_name' : string }
 export interface RegisterEventResponse {
   'created_timestamp_s' : number,
   'code' : string,
   'event_name' : string,
 }
-export interface RegisterRequest { 'code' : string, 'event_name' : string }
+export interface RegisterRequest { 'event_data' : [] | [RegisterEventData] }
 export interface SignedIdAlias { 'credential_jws' : string }
 export interface UserEventData {
   'joined_timestamp_s' : number,

--- a/frontend/src/declarations/early_adopter/early_adopter.did.d.ts
+++ b/frontend/src/declarations/early_adopter/early_adopter.did.d.ts
@@ -77,7 +77,10 @@ export interface PreparedCredentialData {
 export type RegisterError = { 'Internal' : string } |
   { 'External' : string };
 export interface RegisterEventData { 'code' : string, 'event_name' : string }
-export interface RegisterEventRequest { 'event_name' : string }
+export interface RegisterEventRequest {
+  'code' : [] | [string],
+  'event_name' : string,
+}
 export interface RegisterEventResponse {
   'created_timestamp_s' : number,
   'code' : string,

--- a/frontend/src/declarations/early_adopter/early_adopter.did.d.ts
+++ b/frontend/src/declarations/early_adopter/early_adopter.did.d.ts
@@ -11,14 +11,13 @@ export interface DerivationOriginData { 'origin' : string }
 export type DerivationOriginError = { 'Internal' : string } |
   { 'UnsupportedOrigin' : string };
 export interface DerivationOriginRequest { 'frontend_hostname' : string }
-export type EarlyAdopterError = { 'Internal' : string } |
-  { 'External' : string };
 export interface EarlyAdopterResponse {
   'joined_timestamp_s' : number,
-  'events' : Array<EventData>,
+  'events' : Array<UserEventData>,
 }
 export interface EventData {
-  'joined_timestamp_s' : number,
+  'created_timestamp_s' : number,
+  'code' : [] | [string],
   'event_name' : string,
 }
 export interface GetCredentialRequest {
@@ -67,6 +66,7 @@ export interface IssuerConfig {
   'ic_root_key_der' : Uint8Array | number[],
   'frontend_hostname' : string,
 }
+export interface ListEventsResponse { 'events' : Array<EventData> }
 export interface PrepareCredentialRequest {
   'signed_id_alias' : SignedIdAlias,
   'credential_spec' : CredentialSpec,
@@ -74,8 +74,20 @@ export interface PrepareCredentialRequest {
 export interface PreparedCredentialData {
   'prepared_context' : [] | [Uint8Array | number[]],
 }
-export interface RegisterRequest { 'event_name' : [] | [string] }
+export type RegisterError = { 'Internal' : string } |
+  { 'External' : string };
+export interface RegisterEventRequest { 'event_name' : string }
+export interface RegisterEventResponse {
+  'created_timestamp_s' : number,
+  'code' : string,
+  'event_name' : string,
+}
+export interface RegisterRequest { 'code' : string, 'event_name' : string }
 export interface SignedIdAlias { 'credential_jws' : string }
+export interface UserEventData {
+  'joined_timestamp_s' : number,
+  'event_name' : string,
+}
 export interface _SERVICE {
   'configure' : ActorMethod<[IssuerConfig], undefined>,
   'derivation_origin' : ActorMethod<
@@ -89,6 +101,7 @@ export interface _SERVICE {
       { 'Err' : IssueCredentialError }
   >,
   'http_request' : ActorMethod<[HttpRequest], HttpResponse>,
+  'list_events' : ActorMethod<[], ListEventsResponse>,
   'prepare_credential' : ActorMethod<
     [PrepareCredentialRequest],
     { 'Ok' : PreparedCredentialData } |
@@ -97,7 +110,12 @@ export interface _SERVICE {
   'register_early_adopter' : ActorMethod<
     [RegisterRequest],
     { 'Ok' : EarlyAdopterResponse } |
-      { 'Err' : EarlyAdopterError }
+      { 'Err' : RegisterError }
+  >,
+  'register_event' : ActorMethod<
+    [RegisterEventRequest],
+    { 'Ok' : RegisterEventResponse } |
+      { 'Err' : RegisterError }
   >,
   'vc_consent_message' : ActorMethod<
     [Icrc21VcConsentMessageRequest],

--- a/frontend/src/declarations/early_adopter/early_adopter.did.js
+++ b/frontend/src/declarations/early_adopter/early_adopter.did.js
@@ -131,7 +131,7 @@ export const idlFactory = ({ IDL }) => {
     'list_events' : IDL.Func(
         [],
         [IDL.Variant({ 'Ok' : ListEventsResponse, 'Err' : RegisterError })],
-        ['query'],
+        [],
       ),
     'prepare_credential' : IDL.Func(
         [PrepareCredentialRequest],

--- a/frontend/src/declarations/early_adopter/early_adopter.did.js
+++ b/frontend/src/declarations/early_adopter/early_adopter.did.js
@@ -5,6 +5,19 @@ export const idlFactory = ({ IDL }) => {
     'ic_root_key_der' : IDL.Vec(IDL.Nat8),
     'frontend_hostname' : IDL.Text,
   });
+  const AddEventRequest = IDL.Record({
+    'registration_code' : IDL.Opt(IDL.Text),
+    'event_name' : IDL.Text,
+  });
+  const AddEventResponse = IDL.Record({
+    'registration_code' : IDL.Text,
+    'created_timestamp_s' : IDL.Nat32,
+    'event_name' : IDL.Text,
+  });
+  const RegisterError = IDL.Variant({
+    'Internal' : IDL.Text,
+    'External' : IDL.Text,
+  });
   const DerivationOriginRequest = IDL.Record({
     'frontend_hostname' : IDL.Text,
   });
@@ -47,15 +60,11 @@ export const idlFactory = ({ IDL }) => {
     'status_code' : IDL.Nat16,
   });
   const EventRecord = IDL.Record({
+    'registration_code' : IDL.Opt(IDL.Text),
     'created_timestamp_s' : IDL.Nat32,
-    'code' : IDL.Opt(IDL.Text),
     'event_name' : IDL.Text,
   });
   const ListEventsResponse = IDL.Record({ 'events' : IDL.Vec(EventRecord) });
-  const RegisterError = IDL.Variant({
-    'Internal' : IDL.Text,
-    'External' : IDL.Text,
-  });
   const PrepareCredentialRequest = IDL.Record({
     'signed_id_alias' : SignedIdAlias,
     'credential_spec' : CredentialSpec,
@@ -63,12 +72,12 @@ export const idlFactory = ({ IDL }) => {
   const PreparedCredentialData = IDL.Record({
     'prepared_context' : IDL.Opt(IDL.Vec(IDL.Nat8)),
   });
-  const RegisterEventData = IDL.Record({
-    'code' : IDL.Text,
+  const RegisterUserEventData = IDL.Record({
+    'registration_code' : IDL.Text,
     'event_name' : IDL.Text,
   });
-  const RegisterRequest = IDL.Record({
-    'event_data' : IDL.Opt(RegisterEventData),
+  const RegisterUserRequest = IDL.Record({
+    'event_data' : IDL.Opt(RegisterUserEventData),
   });
   const UserEventData = IDL.Record({
     'joined_timestamp_s' : IDL.Nat32,
@@ -77,15 +86,6 @@ export const idlFactory = ({ IDL }) => {
   const EarlyAdopterResponse = IDL.Record({
     'joined_timestamp_s' : IDL.Nat32,
     'events' : IDL.Vec(UserEventData),
-  });
-  const RegisterEventRequest = IDL.Record({
-    'code' : IDL.Opt(IDL.Text),
-    'event_name' : IDL.Text,
-  });
-  const RegisterEventResponse = IDL.Record({
-    'created_timestamp_s' : IDL.Nat32,
-    'code' : IDL.Text,
-    'event_name' : IDL.Text,
   });
   const Icrc21ConsentPreferences = IDL.Record({ 'language' : IDL.Text });
   const Icrc21VcConsentMessageRequest = IDL.Record({
@@ -106,6 +106,11 @@ export const idlFactory = ({ IDL }) => {
     'ConsentMessageUnavailable' : Icrc21ErrorInfo,
   });
   return IDL.Service({
+    'add_event' : IDL.Func(
+        [AddEventRequest],
+        [IDL.Variant({ 'Ok' : AddEventResponse, 'Err' : RegisterError })],
+        [],
+      ),
     'configure' : IDL.Func([IssuerConfig], [], []),
     'derivation_origin' : IDL.Func(
         [DerivationOriginRequest],
@@ -144,13 +149,8 @@ export const idlFactory = ({ IDL }) => {
         [],
       ),
     'register_early_adopter' : IDL.Func(
-        [RegisterRequest],
+        [RegisterUserRequest],
         [IDL.Variant({ 'Ok' : EarlyAdopterResponse, 'Err' : RegisterError })],
-        [],
-      ),
-    'register_event' : IDL.Func(
-        [RegisterEventRequest],
-        [IDL.Variant({ 'Ok' : RegisterEventResponse, 'Err' : RegisterError })],
         [],
       ),
     'vc_consent_message' : IDL.Func(

--- a/frontend/src/declarations/early_adopter/early_adopter.did.js
+++ b/frontend/src/declarations/early_adopter/early_adopter.did.js
@@ -78,7 +78,10 @@ export const idlFactory = ({ IDL }) => {
     'Internal' : IDL.Text,
     'External' : IDL.Text,
   });
-  const RegisterEventRequest = IDL.Record({ 'event_name' : IDL.Text });
+  const RegisterEventRequest = IDL.Record({
+    'code' : IDL.Opt(IDL.Text),
+    'event_name' : IDL.Text,
+  });
   const RegisterEventResponse = IDL.Record({
     'created_timestamp_s' : IDL.Nat32,
     'code' : IDL.Text,

--- a/frontend/src/declarations/early_adopter/early_adopter.did.js
+++ b/frontend/src/declarations/early_adopter/early_adopter.did.js
@@ -46,6 +46,12 @@ export const idlFactory = ({ IDL }) => {
     'headers' : IDL.Vec(HeaderField),
     'status_code' : IDL.Nat16,
   });
+  const EventData = IDL.Record({
+    'created_timestamp_s' : IDL.Nat32,
+    'code' : IDL.Opt(IDL.Text),
+    'event_name' : IDL.Text,
+  });
+  const ListEventsResponse = IDL.Record({ 'events' : IDL.Vec(EventData) });
   const PrepareCredentialRequest = IDL.Record({
     'signed_id_alias' : SignedIdAlias,
     'credential_spec' : CredentialSpec,
@@ -53,18 +59,27 @@ export const idlFactory = ({ IDL }) => {
   const PreparedCredentialData = IDL.Record({
     'prepared_context' : IDL.Opt(IDL.Vec(IDL.Nat8)),
   });
-  const RegisterRequest = IDL.Record({ 'event_name' : IDL.Opt(IDL.Text) });
-  const EventData = IDL.Record({
+  const RegisterRequest = IDL.Record({
+    'code' : IDL.Text,
+    'event_name' : IDL.Text,
+  });
+  const UserEventData = IDL.Record({
     'joined_timestamp_s' : IDL.Nat32,
     'event_name' : IDL.Text,
   });
   const EarlyAdopterResponse = IDL.Record({
     'joined_timestamp_s' : IDL.Nat32,
-    'events' : IDL.Vec(EventData),
+    'events' : IDL.Vec(UserEventData),
   });
-  const EarlyAdopterError = IDL.Variant({
+  const RegisterError = IDL.Variant({
     'Internal' : IDL.Text,
     'External' : IDL.Text,
+  });
+  const RegisterEventRequest = IDL.Record({ 'event_name' : IDL.Text });
+  const RegisterEventResponse = IDL.Record({
+    'created_timestamp_s' : IDL.Nat32,
+    'code' : IDL.Text,
+    'event_name' : IDL.Text,
   });
   const Icrc21ConsentPreferences = IDL.Record({ 'language' : IDL.Text });
   const Icrc21VcConsentMessageRequest = IDL.Record({
@@ -107,6 +122,7 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'http_request' : IDL.Func([HttpRequest], [HttpResponse], ['query']),
+    'list_events' : IDL.Func([], [ListEventsResponse], ['query']),
     'prepare_credential' : IDL.Func(
         [PrepareCredentialRequest],
         [
@@ -119,12 +135,12 @@ export const idlFactory = ({ IDL }) => {
       ),
     'register_early_adopter' : IDL.Func(
         [RegisterRequest],
-        [
-          IDL.Variant({
-            'Ok' : EarlyAdopterResponse,
-            'Err' : EarlyAdopterError,
-          }),
-        ],
+        [IDL.Variant({ 'Ok' : EarlyAdopterResponse, 'Err' : RegisterError })],
+        [],
+      ),
+    'register_event' : IDL.Func(
+        [RegisterEventRequest],
+        [IDL.Variant({ 'Ok' : RegisterEventResponse, 'Err' : RegisterError })],
         [],
       ),
     'vc_consent_message' : IDL.Func(

--- a/frontend/src/declarations/early_adopter/early_adopter.did.js
+++ b/frontend/src/declarations/early_adopter/early_adopter.did.js
@@ -46,12 +46,12 @@ export const idlFactory = ({ IDL }) => {
     'headers' : IDL.Vec(HeaderField),
     'status_code' : IDL.Nat16,
   });
-  const EventData = IDL.Record({
+  const EventRecord = IDL.Record({
     'created_timestamp_s' : IDL.Nat32,
     'code' : IDL.Opt(IDL.Text),
     'event_name' : IDL.Text,
   });
-  const ListEventsResponse = IDL.Record({ 'events' : IDL.Vec(EventData) });
+  const ListEventsResponse = IDL.Record({ 'events' : IDL.Vec(EventRecord) });
   const PrepareCredentialRequest = IDL.Record({
     'signed_id_alias' : SignedIdAlias,
     'credential_spec' : CredentialSpec,
@@ -59,9 +59,12 @@ export const idlFactory = ({ IDL }) => {
   const PreparedCredentialData = IDL.Record({
     'prepared_context' : IDL.Opt(IDL.Vec(IDL.Nat8)),
   });
-  const RegisterRequest = IDL.Record({
+  const RegisterEventData = IDL.Record({
     'code' : IDL.Text,
     'event_name' : IDL.Text,
+  });
+  const RegisterRequest = IDL.Record({
+    'event_data' : IDL.Opt(RegisterEventData),
   });
   const UserEventData = IDL.Record({
     'joined_timestamp_s' : IDL.Nat32,

--- a/frontend/src/declarations/early_adopter/early_adopter.did.js
+++ b/frontend/src/declarations/early_adopter/early_adopter.did.js
@@ -52,6 +52,10 @@ export const idlFactory = ({ IDL }) => {
     'event_name' : IDL.Text,
   });
   const ListEventsResponse = IDL.Record({ 'events' : IDL.Vec(EventRecord) });
+  const RegisterError = IDL.Variant({
+    'Internal' : IDL.Text,
+    'External' : IDL.Text,
+  });
   const PrepareCredentialRequest = IDL.Record({
     'signed_id_alias' : SignedIdAlias,
     'credential_spec' : CredentialSpec,
@@ -73,10 +77,6 @@ export const idlFactory = ({ IDL }) => {
   const EarlyAdopterResponse = IDL.Record({
     'joined_timestamp_s' : IDL.Nat32,
     'events' : IDL.Vec(UserEventData),
-  });
-  const RegisterError = IDL.Variant({
-    'Internal' : IDL.Text,
-    'External' : IDL.Text,
   });
   const RegisterEventRequest = IDL.Record({
     'code' : IDL.Opt(IDL.Text),
@@ -128,7 +128,11 @@ export const idlFactory = ({ IDL }) => {
         ['query'],
       ),
     'http_request' : IDL.Func([HttpRequest], [HttpResponse], ['query']),
-    'list_events' : IDL.Func([], [ListEventsResponse], ['query']),
+    'list_events' : IDL.Func(
+        [],
+        [IDL.Variant({ 'Ok' : ListEventsResponse, 'Err' : RegisterError })],
+        ['query'],
+      ),
     'prepare_credential' : IDL.Func(
         [PrepareCredentialRequest],
         [

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -151,7 +151,7 @@ import socialImage from "../assets/og-image.png";
             const agent = new HttpAgent({ identity, host });
             const webapp = await createActor({ canisterId, agent, fetchRootKey});
             // Login button is only present if the query param with a code appears
-            const registerResponse = await webapp.register_early_adopter({ event_name: eventName, code: currentEvent?.code ?? "" });
+            const registerResponse = await webapp.register_early_adopter({ event_data: [{ event_name: eventName, code: currentEvent?.code ?? "" }] });
             if ("Ok" in registerResponse) {
               trackEvent({ name: "registration_success", event: eventName });
               resolve({ status: 200, message: 'Logged in successfully!' });

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -151,7 +151,7 @@ import socialImage from "../assets/og-image.png";
             const agent = new HttpAgent({ identity, host });
             const webapp = await createActor({ canisterId, agent, fetchRootKey});
             // Login button is only present if the query param with a code appears
-            const registerResponse = await webapp.register_early_adopter({ event_data: [{ event_name: eventName, code: currentEvent?.code ?? "" }] });
+            const registerResponse = await webapp.register_early_adopter({ event_data: [{ event_name: eventName, registration_code: currentEvent?.code ?? "" }] });
             if ("Ok" in registerResponse) {
               trackEvent({ name: "registration_success", event: eventName });
               resolve({ status: 200, message: 'Logged in successfully!' });

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -151,7 +151,7 @@ import socialImage from "../assets/og-image.png";
             const agent = new HttpAgent({ identity, host });
             const webapp = await createActor({ canisterId, agent, fetchRootKey});
             // Login button is only present if the query param with a code appears
-            const registerResponse = await webapp.register_early_adopter({ event_data: [{ event_name: eventName, registration_code: currentEvent?.code ?? "" }] });
+            const registerResponse = await webapp.register_early_adopter({ event_data: [{ event_name: eventName, registration_code: currentEvent?.registrationCode ?? "" }] });
             if ("Ok" in registerResponse) {
               trackEvent({ name: "registration_success", event: eventName });
               resolve({ status: 200, message: 'Logged in successfully!' });

--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -55,14 +55,15 @@ import socialImage from "../assets/og-image.png";
   import { HttpAgent } from "@dfinity/agent";
   import { initOrbiter, trackEvent as trackEventOrbit } from "@junobuild/analytics";
   import { createActor } from "../utils/actor";
-
-  // TODO: Support multiple events.
-  const CURRENT_HARDCODED_EVENT = "DICE2024";
+  import { getEventFromParams } from "../utils/get-event-from-params";
 
   const SATELLITE_ID = import.meta.env.PUBLIC_JUNO_SATELLITE_ID;
   const ORBITER_ID = import.meta.env.PUBLIC_JUNO_ORBITER_ID;
   const isDev = import.meta.env.DEV;
   const skipAnalytics = isDev || SATELLITE_ID === undefined || ORBITER_ID === undefined;
+
+  const currentEvent = getEventFromParams();
+  const eventName = currentEvent?.eventName ?? "unknown";
 
     /**
    * Initialize Juno Analytics only for production, and only if the required environment variables are set; otherwise, ignore.
@@ -77,7 +78,7 @@ import socialImage from "../assets/og-image.png";
       satelliteId: SATELLITE_ID,
     });
 
-    trackEvent({ name: "page_view", event: CURRENT_HARDCODED_EVENT });
+    trackEvent({ name: "page_view", event: eventName });
   }
 
   initAnalytics();
@@ -145,21 +146,24 @@ import socialImage from "../assets/og-image.png";
       authClient.login({
         onSuccess: async () => {
           try {
-            trackEvent({ name: "login_success", event: CURRENT_HARDCODED_EVENT });
+            trackEvent({ name: "login_success", event: eventName });
             const identity = authClient.getIdentity();
             const agent = new HttpAgent({ identity, host });
             const webapp = await createActor({ canisterId, agent, fetchRootKey});
-            const registerResponse = await webapp.register_early_adopter({ event_name: [CURRENT_HARDCODED_EVENT] });
-            trackEvent({ name: "registration_success", event: CURRENT_HARDCODED_EVENT });
+            // Login button is only present if the query param with a code appears
+            const registerResponse = await webapp.register_early_adopter({ event_name: eventName, code: currentEvent?.code ?? "" });
             if ("Ok" in registerResponse) {
+              trackEvent({ name: "registration_success", event: eventName });
               resolve({ status: 200, message: 'Logged in successfully!' });
             } else if ("Err" in registerResponse && "Internal" in registerResponse.Err) {
+              trackEvent({ name: "registration_error", event: eventName });
               resolve({ status: 400, message: registerResponse.Err.Internal });
             } else if ("Err" in registerResponse && "External" in registerResponse.Err) {
+              trackEvent({ name: "registration_error", event: eventName });
               resolve({ status: 400, message: registerResponse.Err.External });
             }
           } catch (err: unknown) {
-            trackEvent({ name: "registration_error", event: CURRENT_HARDCODED_EVENT });
+            trackEvent({ name: "registration_error", event: eventName });
             resolve({ status: 400, message: `There was an error while trying to register. ${err}` });
           } finally {
             busyScreen.classList.add('hide');
@@ -168,10 +172,10 @@ import socialImage from "../assets/og-image.png";
         onError: (err) => {
           // Show nothing if the user cancelled the flow.
           if (err !== "UserInterrupt") {
-            trackEvent({ name: "login_error", event: CURRENT_HARDCODED_EVENT });
+            trackEvent({ name: "login_error", event: eventName });
             showErrorToast("The sign-in process was aborted or did not succeed.");
           } else {
-            trackEvent({ name: "login_interrupted", event: CURRENT_HARDCODED_EVENT });
+            trackEvent({ name: "login_interrupted", event: eventName });
           }
           busyScreen.classList.add('hide');
           resolve({ status: 400, message: err });
@@ -590,6 +594,10 @@ import socialImage from "../assets/og-image.png";
     }
   }
 
+  .hidden {
+    display: none;
+  }
+
   .link {
     text-decoration: underline;
   }
@@ -614,10 +622,6 @@ import socialImage from "../assets/og-image.png";
 
   .design-width--tight { 
     max-width: calc(var(--design-max-width) * .35);
-  }
-
-  .border-radius {
-
   }
 
   .header,

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -29,7 +29,7 @@ import GithubIcon from "../assets/GithubIcon.svg";
           <span>{content.mainTitle3}</span>
         </h1>
         <p class="lead-text">{content.mainLead}</p>
-        <button class="button" data-tid="login-button" data-login>{content.iibuttontext}</button>
+        <button class="button hidden" data-tid="login-button" data-login>{content.iibuttontext}</button>
       </div>
       <div class="card__image">
         <img src={content.mainImage} alt="Internet Identity" />
@@ -86,3 +86,15 @@ import GithubIcon from "../assets/GithubIcon.svg";
   </div>
 </Layout>
 
+<script>
+  import { getEventFromParams } from "../utils/get-event-from-params";
+
+  const enableLogin = () => {
+    const loginButton = document.querySelector("[data-login]");
+    const currentEvent = getEventFromParams();
+    if (currentEvent && loginButton) {
+      loginButton.classList.remove("hidden");
+    }
+  };
+  enableLogin();
+</script>

--- a/frontend/src/utils/get-event-from-params.ts
+++ b/frontend/src/utils/get-event-from-params.ts
@@ -1,0 +1,15 @@
+const EVENT_NAME_PARAM_KEY = "e";
+const EVENT_CODE_PARAM_KEY = "c";
+export const getEventFromParams = () => {
+  const url = new URL(window.location.href);
+  const params = url.searchParams;
+  const eventName = params.get(EVENT_NAME_PARAM_KEY);
+  const code = params.get(EVENT_CODE_PARAM_KEY);
+  if (!eventName || !code) {
+    return undefined;
+  }
+  return {
+    eventName,
+    code
+  }
+};

--- a/frontend/src/utils/get-event-from-params.ts
+++ b/frontend/src/utils/get-event-from-params.ts
@@ -4,12 +4,12 @@ export const getEventFromParams = () => {
   const url = new URL(window.location.href);
   const params = url.searchParams;
   const eventName = params.get(EVENT_NAME_PARAM_KEY);
-  const code = params.get(EVENT_CODE_PARAM_KEY);
-  if (!eventName || !code) {
+  const registrationCode = params.get(EVENT_CODE_PARAM_KEY);
+  if (!eventName || !registrationCode) {
     return undefined;
   }
   return {
     eventName,
-    code
+    registrationCode,
   }
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,6 +126,7 @@ pub struct RegisterRequest {
 #[derive(CandidType, Clone, Deserialize)]
 pub struct RegisterEventRequest {
     pub event_name: String,
+    pub code: Option<String>,
 }
 
 #[derive(CandidType, Clone, Deserialize)]
@@ -610,10 +611,17 @@ async fn register_event(
         )));
     }
     if is_admin(user_id).await {
-        let Some(code) = generate_random_code().await else {
-            return Err(RegisterError::Internal(
-                "There was an error creating the random code. Please try again.".to_string(),
-            ));
+        let code = match request.code {
+            Some(code) => code,
+            None => {
+                let Some(code) = generate_random_code().await else {
+                    return Err(RegisterError::Internal(
+                        "There was an error creating the random code. Please try again."
+                            .to_string(),
+                    ));
+                };
+                code
+            }
         };
         EVENTS.with_borrow_mut(|events| {
             let new_event = EventRecord {

--- a/src/main.rs
+++ b/src/main.rs
@@ -538,7 +538,7 @@ async fn is_admin(id: Principal) -> bool {
 
 #[query]
 #[candid_method]
-async fn list_events() -> ListEventsResponse {
+async fn list_events() -> Result<ListEventsResponse, RegisterError> {
     let user_id = caller();
     let is_controller = is_admin(user_id).await;
     EVENTS.with_borrow(|events| {
@@ -550,7 +550,7 @@ async fn list_events() -> ListEventsResponse {
                 code: if is_controller { Some(data.code) } else { None },
             })
             .collect();
-        ListEventsResponse { events }
+        Ok(ListEventsResponse { events })
     })
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ impl Storable for EventRecord {
 #[derive(CandidType, Clone, Deserialize)]
 pub struct UserEventData {
     pub joined_timestamp_s: u32,
-    pub event_name: String,
+    pub event_name: EventName,
 }
 
 // Internal container of per-user data.
@@ -126,13 +126,13 @@ pub struct RegisterRequest {
 
 #[derive(CandidType, Clone, Deserialize)]
 pub struct RegisterEventRequest {
-    pub event_name: String,
+    pub event_name: EventName,
     pub code: Option<String>,
 }
 
 #[derive(CandidType, Clone, Deserialize)]
 pub struct RegisterEventResponse {
-    pub event_name: String,
+    pub event_name: EventName,
     pub code: String,
     pub created_timestamp_s: u32,
 }
@@ -140,7 +140,7 @@ pub struct RegisterEventResponse {
 // User-facing container per-event data.
 #[derive(CandidType, Clone, Deserialize)]
 pub struct EventData {
-    pub event_name: String,
+    pub event_name: EventName,
     pub code: Option<String>,
     pub created_timestamp_s: u32,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -673,7 +673,7 @@ fn register_early_adopter(
         // Exit early if the passed code doesn't match the event code
         if event_record.registration_code != requested_event.registration_code {
             return Err(RegisterError::Internal(format!(
-                "Code doesn't match for Event {}",
+                "Registration code doesn't match for Event {}",
                 requested_event.event_name
             )));
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -537,7 +537,7 @@ async fn is_admin(id: Principal) -> bool {
 }
 
 #[query]
-#[candid_method]
+#[candid_method(query)]
 async fn list_events() -> Result<ListEventsResponse, RegisterError> {
     let user_id = caller();
     let is_controller = is_admin(user_id).await;

--- a/tests/issue_credential.rs
+++ b/tests/issue_credential.rs
@@ -1123,7 +1123,7 @@ fn should_fail_to_register_user_with_empty_event_name() -> Result<(), CallError>
 }
 
 #[test]
-fn only_controllers_can_register_events() -> Result<(), CallError> {
+fn only_controllers_can_add_events() -> Result<(), CallError> {
     let env = env();
     let issuer_id = install_issuer(&env, &DUMMY_ISSUER_INIT);
     let user = principal_1();
@@ -1145,7 +1145,7 @@ fn only_controllers_can_register_events() -> Result<(), CallError> {
 }
 
 #[test]
-fn should_register_event_with_random_code() -> Result<(), CallError> {
+fn should_add_event_with_random_code() -> Result<(), CallError> {
     let env = env();
     let issuer_id = install_issuer(&env, &DUMMY_ISSUER_INIT);
     let empty_event = AddEventRequest {
@@ -1166,7 +1166,7 @@ fn should_register_event_with_random_code() -> Result<(), CallError> {
 }
 
 #[test]
-fn should_register_event_with_code() -> Result<(), CallError> {
+fn should_add_event_with_code() -> Result<(), CallError> {
     let env = env();
     let issuer_id = install_issuer(&env, &DUMMY_ISSUER_INIT);
     let code = "code".to_string();
@@ -1214,7 +1214,7 @@ fn should_not_register_same_event_name_twice() -> Result<(), CallError> {
 }
 
 #[test]
-fn should_register_events() -> Result<(), CallError> {
+fn should_add_events() -> Result<(), CallError> {
     let env = env();
     let issuer_id = install_issuer(&env, &DUMMY_ISSUER_INIT);
     let event_1 = AddEventRequest {


### PR DESCRIPTION
Main motivation is to require a code when the user registers for an event.

At the moment, the only way to add the code is using query params. In the future, users will be able to login without code and then add events.

In this PR:
* Add backend endpoints: register_event (only for controllers) and list_events
* Hide the login button by default and enable it if there is an event and code in the query params.
* Backend endpoint register_early_adopter checks event data (if present) before registering user.